### PR TITLE
fixed arg mobile numbers validators

### DIFF
--- a/smsc/validations.py
+++ b/smsc/validations.py
@@ -6,9 +6,9 @@ from smsc.exceptions import AreaCodeSMSCError, LocalNumberSMSCError, PhoneNumber
 def validate_phone_number(area_code, local_number):
     if not re.match(r'^\d{2,4}$', area_code):
         raise AreaCodeSMSCError(area_code, 'area_code: This param is invalid')
-    if not re.match(r'^\d{6,8}$', local_number):
+    if not re.match(r'^\d{8,13}$', local_number):
         raise LocalNumberSMSCError(local_number, 'local_number: This param is invalid')
-    if not re.match(r'^\d{10}$', area_code + local_number):
+    if not re.match(r'^\d{10,13}$', area_code + local_number):
         raise PhoneNumberLongSMSCError(area_code + local_number, 'The number should be 10 digits')
 
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,0 +1,25 @@
+import unittest
+import mock
+from mock import MagicMock
+from smsc import SMSC
+
+from smsc.utils import sms_is_limited, sms_length, sms_rest, sms_parse
+
+
+class TestFunctional(unittest.TestCase):
+
+    @mock.patch('smsc.smsc.requests')
+    def test_send_mobile_number(self, mock_request):
+        resp_mock = MagicMock()
+        resp_mock.json.return_value = {'data': {'id': 16829892, 'sms': 1},
+                                       'message': 'Mensaje enviado.',
+                                       'code': 200
+                                       }
+
+        mock_request.get.return_value = resp_mock
+        sms = SMSC(alias='test', apikey='test')
+        resp = sms.send(area_code='011',
+                        local_number='1531268974', msg='testing')
+        assert mock_request.get.called
+        assert resp == {'data': {'id': 16829892, 'sms': 1},
+                        'message': 'Mensaje enviado.', 'code': 200}


### PR DESCRIPTION
I wasn't able to send messages to arg mobile numbers since validator regex was wrong. I modified the allowed length and now it's working fine. Please go through my changes and let me know. Thank you.